### PR TITLE
Fix Docker Build by Ensuring Cache Directories Exist

### DIFF
--- a/ci/conda/recipes/cudf/build.sh
+++ b/ci/conda/recipes/cudf/build.sh
@@ -23,6 +23,9 @@ export CCACHE_DEBUGDIR=${SRC_DIR}/ccache_debug
 export CCACHE_SLOPPINESS="system_headers"
 export CCACHE_NOHASHDIR=1
 
+# Double check that the cache dir has been created
+mkdir -p ${CCACHE_DIR}
+
 # CMake with nvcc uses -isystem=/path instead of -isystem /path which ccache doesnt like. Replace that
 REPLACE_ISYSTEM="ARGS=()\nfor i in \"\${@}\"; do\n  ARGS+=(\${i/\"-isystem=/\"/\"-isystem /\"})\ndone\n"
 

--- a/ci/conda/recipes/libcudf/build.sh
+++ b/ci/conda/recipes/libcudf/build.sh
@@ -26,6 +26,9 @@ export CCACHE_SLOPPINESS="system_headers"
 export CC=${GCC}
 export CXX=${GXX}
 
+# Double check that the cache dir has been created
+mkdir -p ${CCACHE_DIR}
+
 # CMake with nvcc uses -isystem=/path instead of -isystem /path which ccache doesnt like. Replace that
 REPLACE_ISYSTEM="ARGS=()\nfor i in \"\${@}\"; do\n  ARGS+=(\${i/\"-isystem=/\"/\"-isystem /\"})\ndone\n"
 

--- a/ci/conda/recipes/morpheus/morpheus_build.sh
+++ b/ci/conda/recipes/morpheus/morpheus_build.sh
@@ -26,6 +26,9 @@ export CCACHE_BASEDIR=$(realpath ${SRC_DIR}/..)
 if [[ -n "${MORPHEUS_CACHE_DIR}" ]]; then
    # Set the cache variable, then set the Staging prefix to allow for host searching
    CMAKE_ARGS="-DMORPHEUS_CACHE_DIR=${MORPHEUS_CACHE_DIR} ${CMAKE_ARGS}"
+
+   # Double check that the cache dir has been created
+   mkdir -p ${MORPHEUS_CACHE_DIR}
 fi
 
 CMAKE_ARGS="-DCMAKE_MESSAGE_CONTEXT_SHOW=ON ${CMAKE_ARGS}"

--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -48,13 +48,6 @@ echo ""
 # Export variables for the cache
 export MORPHEUS_CACHE_DIR=${MORPHEUS_CACHE_DIR:-"${MORPHEUS_ROOT}/.cache"}
 
-# Ensure the build directory exists
-export CONDA_BLD_DIR=${CONDA_BLD_DIR:-"${MORPHEUS_CACHE_DIR}/conda-build"}
-mkdir -p ${CONDA_BLD_DIR}
-
-# Where the conda packages are saved to outside of the conda environment
-CONDA_BLD_OUTPUT=${CONDA_BLD_OUTPUT:-"${MORPHEUS_ROOT}/.conda-bld"}
-
 # Export CCACHE variables
 export CCACHE_DIR="${MORPHEUS_CACHE_DIR}/ccache"
 export CCACHE_NOHASHDIR=1
@@ -62,6 +55,10 @@ export CMAKE_GENERATOR="Ninja"
 export CMAKE_C_COMPILER_LAUNCHER="ccache"
 export CMAKE_CXX_COMPILER_LAUNCHER="ccache"
 export CMAKE_CUDA_COMPILER_LAUNCHER="ccache"
+
+# Ensure the necessary folders exist before continuing
+mkdir -p ${MORPHEUS_CACHE_DIR}
+mkdir -p ${CCACHE_DIR}
 
 # Holds the arguments in an array to allow for complex json objects
 CONDA_ARGS_ARRAY=()

--- a/docker/build_container.sh
+++ b/docker/build_container.sh
@@ -29,7 +29,6 @@ LINUX_VER=${LINUX_VER:-20.04}
 RAPIDS_VER=${RAPIDS_VER:-21.10}
 PYTHON_VER=${PYTHON_VER:-3.8}
 TENSORRT_VERSION=${TENSORRT_VERSION:-8.2.1.3}
-NEO_GIT_URL=${NEO_GIT_URL:-UNKNOWN}
 
 DOCKER_ARGS="-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
 DOCKER_ARGS="${DOCKER_ARGS} --target ${DOCKER_TARGET}"
@@ -40,7 +39,6 @@ DOCKER_ARGS="${DOCKER_ARGS} --build-arg LINUX_VER=${LINUX_VER}"
 DOCKER_ARGS="${DOCKER_ARGS} --build-arg RAPIDS_VER=${RAPIDS_VER}"
 DOCKER_ARGS="${DOCKER_ARGS} --build-arg PYTHON_VER=${PYTHON_VER}"
 DOCKER_ARGS="${DOCKER_ARGS} --build-arg TENSORRT_VERSION=${TENSORRT_VERSION}"
-DOCKER_ARGS="${DOCKER_ARGS} --build-arg NEO_GIT_URL=${NEO_GIT_URL}"
 DOCKER_ARGS="${DOCKER_ARGS} --network=host"
 
 if [[ "${DOCKER_BUILDKIT}" = "1" ]]; then
@@ -62,7 +60,6 @@ echo "   LINUX_VER       : ${LINUX_VER}"
 echo "   RAPIDS_VER      : ${RAPIDS_VER}"
 echo "   PYTHON_VER      : ${PYTHON_VER}"
 echo "   TENSORRT_VERSION: ${TENSORRT_VERSION}"
-echo "   NEO_GIT_URL     : ${NEO_GIT_URL}"
 echo ""
 echo "   COMMAND: docker buildx build ${DOCKER_ARGS} -f docker/Dockerfile ."
 echo "   Note: add '--progress plain' to DOCKER_ARGS to show all container build output"

--- a/docker/build_container_release.sh
+++ b/docker/build_container_release.sh
@@ -18,7 +18,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 export DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME:-"nvcr.io/nvidia/morpheus/morpheus"}
-export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-"latest"}
+export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-"runtime-$(git describe --tags --abbrev=0)"}
 export DOCKER_TARGET=${DOCKER_TARGET:-"runtime"}
 
 # Call the general build script

--- a/docker/run_container_dev.sh
+++ b/docker/run_container_dev.sh
@@ -39,4 +39,6 @@ fi
 
 echo -e "${g}Launching ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}...${x}"
 
+set -x
 docker run --rm -ti ${DOCKER_ARGS} ${DOCKER_EXTRA_ARGS} ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} "${@:-bash}"
+set +x


### PR DESCRIPTION
With a fresh build, errors occur which show the following:
```
Check for working C compiler: $BUILD_PREFIX/bin/x86_64-conda-linux-gnu-gcc - broken
...
ccache: error: Failed to write to /workspace/.cache/ccache/ccache.log: No such file or directory
```
This PR fixes that by ensuring the cache directories exist

Closes #7 