### PR TITLE
Log parsing example updates

### DIFF
--- a/data/bert-base-cased-vocab.txt
+++ b/data/bert-base-cased-vocab.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94f958e06f58dbca894d1fff97e59242d2dbf188ce776a08dee9c7faf8096211
+size 219226

--- a/data/bert-base-cased-vocab.txt
+++ b/data/bert-base-cased-vocab.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94f958e06f58dbca894d1fff97e59242d2dbf188ce776a08dee9c7faf8096211
-size 219226

--- a/examples/log_parsing/README.md
+++ b/examples/log_parsing/README.md
@@ -53,7 +53,7 @@ docker run --gpus=1 --rm -p8000:8000 -p8001:8001 -p8002:8002 -v $PWD:/models nvc
 Run the following in your Morpheus container to start the log parsing pipeline:
 
 ```
-python ./examples/log-parsing/run.py \
+python ./examples/log_parsing/run.py \
     --num_threads 1 \
     --input_file ./models/datasets/validation-data/log-parsing-validation-data-input.csv \
     --output_file ./log-parsing-output.jsonlines \

--- a/examples/log_parsing/README.md
+++ b/examples/log_parsing/README.md
@@ -57,8 +57,8 @@ python ./examples/log_parsing/run.py \
     --num_threads 1 \
     --input_file ./models/datasets/validation-data/log-parsing-validation-data-input.csv \
     --output_file ./log-parsing-output.jsonlines \
-    --model_vocab_hash_file=./data/bert-base-cased-hash.txt \
-    --model_vocab_file=./data/bert-base-cased-vocab.txt \
+    --model_vocab_hash_file=./models/training-tuning-scripts/sid-models/resources/bert-base-cased-hash.txt \
+    --model_vocab_file=./models/training-tuning-scripts/sid-models/resources/bert-base-cased-vocab.txt \
     --model_seq_length=256 \
     --model_name log-parsing-onnx \
     --model_config_file=./models/log-parsing-models/log-parsing-config-20220418.json \

--- a/examples/log_parsing/run.py
+++ b/examples/log_parsing/run.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import click
-import psutil
+import os
 from inference import LogParsingInferenceStage
 from postprocessing import LogParsingPostProcessingStage
 from preprocessing import PreprocessLogParsingStage
@@ -32,7 +32,7 @@ from morpheus.pipeline.preprocessing import DeserializeStage
 @click.command()
 @click.option(
     "--num_threads",
-    default=psutil.cpu_count(),
+    default=os.cpu_count(),
     type=click.IntRange(min=1),
     help="Number of internal pipeline threads to use",
 )


### PR DESCRIPTION
~- Add missing vocabulary file (`bert-base-cased-vocab.txt`)~
- Fix path to run script in example README
- Use `os.cpu_count()` instead of `psutil.cpu_count()` for pipeline config's `num_threads`