### PR TITLE
Fixing pytest in conda build

### DIFF
--- a/ci/conda/recipes/morpheus/meta.yaml
+++ b/ci/conda/recipes/morpheus/meta.yaml
@@ -113,6 +113,7 @@ outputs:
         - cudatoolkit {{ cuda_version }}.*
         - pytest
         - pytest-cov
+        - pytest-benchmark
       source_files:
         - pyproject.toml
         - tests/*


### PR DESCRIPTION
Conda build was missing `pytest-benchmark`