### PR TITLE
Changing runtime-22.04 to 22.04-runtime

### DIFF
--- a/docker/build_container_release.sh
+++ b/docker/build_container_release.sh
@@ -18,7 +18,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 export DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME:-"nvcr.io/nvidia/morpheus/morpheus"}
-export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-"runtime-$(git describe --tags --abbrev=0)"}
+export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-"$(git describe --tags --abbrev=0)-runtime"}
 export DOCKER_TARGET=${DOCKER_TARGET:-"runtime"}
 
 # Call the general build script

--- a/docker/run_container_release.sh
+++ b/docker/run_container_release.sh
@@ -24,7 +24,7 @@ y="\033[0;33m"
 x="\033[0m"
 
 DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME:-"nvcr.io/nvidia/morpheus/morpheus"}
-DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-"runtime-$(git describe --tags --abbrev=0)"}
+DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-"$(git describe --tags --abbrev=0)-release"}
 DOCKER_EXTRA_ARGS=${DOCKER_EXTRA_ARGS:-""}
 
 DOCKER_ARGS="--env WORKSPACE_VOLUME=${PWD} -v $PWD/models:/workspace/models --net=host --gpus=all ${DOCKER_EXTRA_ARGS}"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,7 +71,7 @@ To get started, first pull the NGC container:
 
 .. code-block:: console
 
-   $ docker pull nvcr.io/nvidia/morpheus/morpheus:runtime-22.04-latest
+   $ docker pull nvcr.io/nvidia/morpheus/morpheus:22.04-runtime
 
 Launch an interactive container to start using Morpheus:
 


### PR DESCRIPTION
Updates the buid/run docker release scripts to use the new format.