### PR TITLE
Adding option to specify a conda channel alias during conda-build

### DIFF
--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -37,6 +37,9 @@ export MORPHEUS_ROOT=${MORPHEUS_ROOT:-$(git rev-parse --show-toplevel)}
 # Set the tag for the neo commit to use
 export NEO_GIT_TAG=${NEO_GIT_TAG:-"5b55e37c6320c1a5747311a1e29e7ebb049d12bc"}
 
+# Set CONDA_CHANNEL_ALIAS to mimic the conda config channel_alias property during the build
+CONDA_CHANNEL_ALIAS=${CONDA_CHANNEL_ALIAS:-""}
+
 export CUDA="$(conda list | grep cudatoolkit | egrep -o "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+")"
 export PYTHON_VER="$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")"
 export CUDA=11.4.1
@@ -74,8 +77,11 @@ fi
 # Choose default variants
 CONDA_ARGS_ARRAY+=("--variants" "{python: 3.8}")
 
-# And default channels
-CONDA_ARGS_ARRAY+=("-c" "rapidsai" "-c" "nvidia" "-c" "nvidia/label/dev" "-c" "conda-forge")
+# And default channels (with optional channel alias)
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}rapidsai")
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}nvidia")
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}nvidia/label/dev")
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}conda-forge")
 
 if hasArg click_completion; then
    echo "Running conda-build for click_completion..."

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,7 +114,11 @@ COPY docker/conda/environments/cuda${CUDA_VER}_dev.yml ./docker/conda/environmen
 # Update the morpheus environment
 RUN --mount=type=bind,from=conda_bld_deps,source=/opt/conda/conda-bld,target=/opt/conda/conda-bld \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
+    # Temp add channel_alias to get around conda 404 errors
+    conda config --env --set channel_alias http://conda-mirror.gpuci.io/ &&\
     /opt/conda/bin/mamba env update -n morpheus --file docker/conda/environments/cuda${CUDA_VER}_dev.yml &&\
+    # Remove channel_alias to use the normal channel in the container
+    conda config --env --remove-key channel_alias &&\
     # Clean and activate
     conda clean -afy
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,6 +74,7 @@ RUN --mount=type=ssh \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     source activate base &&\
     # Run with --no-test for now until we can build with builtkit and default nvidia runtime
+    # Temp add CONDA_CHANNEL_ALIAS to get around conda-build 404 errors
     MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" CONDA_CHANNEL_ALIAS="http://conda-mirror.gpuci.io/" ./ci/conda/recipes/run_conda_build.sh libcudf cudf
 
 # ============ Stage: conda_env ============
@@ -128,6 +129,7 @@ RUN --mount=type=ssh \
     --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locked \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     source activate base &&\
+    # Temp add CONDA_CHANNEL_ALIAS to get around conda-build 404 errors
     MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" CONDA_CHANNEL_ALIAS="http://conda-mirror.gpuci.io/" ./ci/conda/recipes/run_conda_build.sh morpheus
 
 # ============ Stage: runtime ============

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN --mount=type=ssh \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     source activate base &&\
     # Run with --no-test for now until we can build with builtkit and default nvidia runtime
-    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" ./ci/conda/recipes/run_conda_build.sh libcudf cudf
+    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" CONDA_CHANNEL_ALIAS="http://conda-mirror.gpuci.io/" ./ci/conda/recipes/run_conda_build.sh libcudf cudf
 
 # ============ Stage: conda_env ============
 # Create the conda environment and install all dependencies
@@ -128,7 +128,7 @@ RUN --mount=type=ssh \
     --mount=type=cache,id=workspace_cache,target=/workspace/.cache,sharing=locked \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     source activate base &&\
-    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" ./ci/conda/recipes/run_conda_build.sh morpheus
+    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" CONDA_CHANNEL_ALIAS="http://conda-mirror.gpuci.io/" ./ci/conda/recipes/run_conda_build.sh morpheus
 
 # ============ Stage: runtime ============
 # Setup container for runtime environment


### PR DESCRIPTION
If there are 404 errors for the channels `nvidia` or `rapidsai`, then the conda-build scripts can fail. This adds the option to specify `CONDA_CHANNEL_ALIAS` before calling `./ci/conda/recipes/run_conda_build.sh`.

Since we are currently getting these errors, the option has been enabled by default in the docker container builds but will not be used unless manually specified.