### PR TITLE
Adding build arg to use conda mirror

### DIFF
--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -78,17 +78,10 @@ fi
 CONDA_ARGS_ARRAY+=("--variants" "{python: 3.8}")
 
 # And default channels (with optional channel alias)
-CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}rapidsai")
-CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}nvidia")
-CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}nvidia/label/dev")
-CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}conda-forge")
-
-if hasArg click_completion; then
-   echo "Running conda-build for click_completion..."
-   set -x
-   conda ${CONDA_COMMAND} "${CONDA_ARGS_ARRAY[@]}" ${CONDA_ARGS} ci/conda/recipes/click_completion
-   set +x
-fi
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS:+"${CONDA_CHANNEL_ALIAS%/}/"}rapidsai")
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS:+"${CONDA_CHANNEL_ALIAS%/}/"}nvidia")
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS:+"${CONDA_CHANNEL_ALIAS%/}/"}nvidia/label/dev")
+CONDA_ARGS_ARRAY+=("-c" "conda-forge")
 
 if hasArg libneo; then
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,9 @@ ARG RAPIDS_VER=21.10
 ARG PYTHON_VER=3.8
 ARG CONDA_CHANNEL=rapidsai
 
+# Temp option to set conda channel_alias property during build
+ARG CONDA_CHANNEL_ALIAS
+
 # The TensorRT Version must be the full version (i.e. 7.2.2.3) and match Triton EXACTLY
 ARG TENSORRT_VERSION=8.2.1.3
 
@@ -64,6 +67,8 @@ RUN conda config --set ssl_verify false &&\
 # Now build the conda dependency packages
 FROM base as conda_bld_deps
 
+ARG CONDA_CHANNEL_ALIAS
+
 # COPY the files necessary to build the cudf package. Dont copy more otherwise the cache will get invalided often
 COPY ci/conda/recipes/cudf/ ./ci/conda/recipes/cudf/
 COPY ci/conda/recipes/libcudf/ ./ci/conda/recipes/libcudf/
@@ -75,7 +80,7 @@ RUN --mount=type=ssh \
     source activate base &&\
     # Run with --no-test for now until we can build with builtkit and default nvidia runtime
     # Temp add CONDA_CHANNEL_ALIAS to get around conda-build 404 errors
-    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" CONDA_CHANNEL_ALIAS="http://conda-mirror.gpuci.io/" ./ci/conda/recipes/run_conda_build.sh libcudf cudf
+    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" ./ci/conda/recipes/run_conda_build.sh libcudf cudf
 
 # ============ Stage: conda_env ============
 # Create the conda environment and install all dependencies
@@ -107,6 +112,8 @@ SHELL ["/bin/bash", "-c"]
 # Create the development conda environment
 FROM conda_env as conda_env_dev
 
+ARG CONDA_CHANNEL_ALIAS
+
 # Copy the development dependencies file
 COPY docker/conda/environments/requirements.txt ./docker/conda/environments/
 COPY docker/conda/environments/cuda${CUDA_VER}_dev.yml ./docker/conda/environments/
@@ -115,7 +122,7 @@ COPY docker/conda/environments/cuda${CUDA_VER}_dev.yml ./docker/conda/environmen
 RUN --mount=type=bind,from=conda_bld_deps,source=/opt/conda/conda-bld,target=/opt/conda/conda-bld \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     # Temp add channel_alias to get around conda 404 errors
-    conda config --env --set channel_alias http://conda-mirror.gpuci.io/ &&\
+    conda config --env --set channel_alias ${CONDA_CHANNEL_ALIAS:-"https://conda.anaconda.org"} &&\
     /opt/conda/bin/mamba env update -n morpheus --file docker/conda/environments/cuda${CUDA_VER}_dev.yml &&\
     # Remove channel_alias to use the normal channel in the container
     conda config --env --remove-key channel_alias &&\
@@ -126,6 +133,8 @@ RUN --mount=type=bind,from=conda_bld_deps,source=/opt/conda/conda-bld,target=/op
 # Now build the morpheus conda package
 FROM conda_bld_deps as conda_bld_morpheus
 
+ARG CONDA_CHANNEL_ALIAS
+
 # Copy the source
 COPY . ./
 
@@ -134,7 +143,7 @@ RUN --mount=type=ssh \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     source activate base &&\
     # Temp add CONDA_CHANNEL_ALIAS to get around conda-build 404 errors
-    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" CONDA_CHANNEL_ALIAS="http://conda-mirror.gpuci.io/" ./ci/conda/recipes/run_conda_build.sh morpheus
+    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" ./ci/conda/recipes/run_conda_build.sh morpheus
 
 # ============ Stage: runtime ============
 # Setup container for runtime environment


### PR DESCRIPTION
To use a conda channel alias/mirror, use the following:

```
DOCKER_EXTRA_ARGS="--build-arg CONDA_CHANNEL_ALIAS=<alias_url>" ./build_container_release.sh
```