### PR TITLE
Clear log handlers after each test

### DIFF
--- a/ci/conda/recipes/run_conda_build.sh
+++ b/ci/conda/recipes/run_conda_build.sh
@@ -78,17 +78,10 @@ fi
 CONDA_ARGS_ARRAY+=("--variants" "{python: 3.8}")
 
 # And default channels (with optional channel alias)
-CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}rapidsai")
-CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}nvidia")
-CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}nvidia/label/dev")
-CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS}conda-forge")
-
-if hasArg click_completion; then
-   echo "Running conda-build for click_completion..."
-   set -x
-   conda ${CONDA_COMMAND} "${CONDA_ARGS_ARRAY[@]}" ${CONDA_ARGS} ci/conda/recipes/click_completion
-   set +x
-fi
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS:+"${CONDA_CHANNEL_ALIAS%/}/"}rapidsai")
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS:+"${CONDA_CHANNEL_ALIAS%/}/"}nvidia")
+CONDA_ARGS_ARRAY+=("-c" "${CONDA_CHANNEL_ALIAS:+"${CONDA_CHANNEL_ALIAS%/}/"}nvidia/label/dev")
+CONDA_ARGS_ARRAY+=("-c" "conda-forge")
 
 if hasArg libneo; then
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,9 @@ ARG RAPIDS_VER=21.10
 ARG PYTHON_VER=3.8
 ARG CONDA_CHANNEL=rapidsai
 
+# Temp option to set conda channel_alias property during build
+ARG CONDA_CHANNEL_ALIAS
+
 # The TensorRT Version must be the full version (i.e. 7.2.2.3) and match Triton EXACTLY
 ARG TENSORRT_VERSION=8.2.1.3
 
@@ -64,6 +67,8 @@ RUN conda config --set ssl_verify false &&\
 # Now build the conda dependency packages
 FROM base as conda_bld_deps
 
+ARG CONDA_CHANNEL_ALIAS
+
 # COPY the files necessary to build the cudf package. Dont copy more otherwise the cache will get invalided often
 COPY ci/conda/recipes/cudf/ ./ci/conda/recipes/cudf/
 COPY ci/conda/recipes/libcudf/ ./ci/conda/recipes/libcudf/
@@ -75,7 +80,7 @@ RUN --mount=type=ssh \
     source activate base &&\
     # Run with --no-test for now until we can build with builtkit and default nvidia runtime
     # Temp add CONDA_CHANNEL_ALIAS to get around conda-build 404 errors
-    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" CONDA_CHANNEL_ALIAS="http://conda-mirror.gpuci.io/" ./ci/conda/recipes/run_conda_build.sh libcudf cudf
+    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" ./ci/conda/recipes/run_conda_build.sh libcudf cudf
 
 # ============ Stage: conda_env ============
 # Create the conda environment and install all dependencies
@@ -107,6 +112,8 @@ SHELL ["/bin/bash", "-c"]
 # Create the development conda environment
 FROM conda_env as conda_env_dev
 
+ARG CONDA_CHANNEL_ALIAS
+
 # Copy the development dependencies file
 COPY docker/conda/environments/requirements.txt ./docker/conda/environments/
 COPY docker/conda/environments/cuda${CUDA_VER}_dev.yml ./docker/conda/environments/
@@ -115,7 +122,7 @@ COPY docker/conda/environments/cuda${CUDA_VER}_dev.yml ./docker/conda/environmen
 RUN --mount=type=bind,from=conda_bld_deps,source=/opt/conda/conda-bld,target=/opt/conda/conda-bld \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     # Temp add channel_alias to get around conda 404 errors
-    conda config --env --set channel_alias http://conda-mirror.gpuci.io/ &&\
+    conda config --env --set channel_alias ${CONDA_CHANNEL_ALIAS:-"https://conda.anaconda.org"} &&\
     /opt/conda/bin/mamba env update -n morpheus --file docker/conda/environments/cuda${CUDA_VER}_dev.yml &&\
     # Remove channel_alias to use the normal channel in the container
     conda config --env --remove-key channel_alias &&\
@@ -126,6 +133,8 @@ RUN --mount=type=bind,from=conda_bld_deps,source=/opt/conda/conda-bld,target=/op
 # Now build the morpheus conda package
 FROM conda_bld_deps as conda_bld_morpheus
 
+ARG CONDA_CHANNEL_ALIAS
+
 # Copy the source
 COPY . ./
 
@@ -134,7 +143,7 @@ RUN --mount=type=ssh \
     --mount=type=cache,id=conda_pkgs,target=/opt/conda/pkgs,sharing=locked \
     source activate base &&\
     # Temp add CONDA_CHANNEL_ALIAS to get around conda-build 404 errors
-    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" CONDA_CHANNEL_ALIAS="http://conda-mirror.gpuci.io/" ./ci/conda/recipes/run_conda_build.sh morpheus
+    MORPHEUS_ROOT=/workspace CONDA_BLD_DIR=/opt/conda/conda-bld CONDA_ARGS="--no-test" ./ci/conda/recipes/run_conda_build.sh morpheus
 
 # ============ Stage: runtime ============
 # Setup container for runtime environment

--- a/examples/abp_pcap_detection/README.md
+++ b/examples/abp_pcap_detection/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ To run this example, an instance of Triton Inference Server and a sample dataset
 
 ### Triton Inference Server
 ```bash
-docker pull nvcr.io/nvidia/tritonserver:21.12-py3
+docker pull nvcr.io/nvidia/tritonserver:22.02-py3
 ```
 
 ##### Deploy Triton Inference Server
@@ -35,7 +35,7 @@ Bind the provided `abp-pcap-xgb` directory to the docker container model repo at
 cd <MORPHEUS_ROOT>/examples/abp_pcap_detection
 
 # Launch the container
-docker run --rm --gpus=all -p 8000:8000 -p 8001:8001 -p 8002:8002 -v $PWD/models/abp-pcap-xgb:/models/abp-pcap-xgb --name tritonserver nvcr.io/nvidia/tritonserver:21.12-py3 tritonserver --model-repository=/models --exit-on-error=false --model-control-mode=poll --repository-poll-secs=30
+docker run --rm --gpus=all -p 8000:8000 -p 8001:8001 -p 8002:8002 -v $PWD/abp-pcap-xgb:/models/abp-pcap-xgb --name tritonserver nvcr.io/nvidia/tritonserver:22.02-py3 tritonserver --model-repository=/models --exit-on-error=false --model-control-mode=poll --repository-poll-secs=30
 ```
 
 ##### Verify Model Deployment
@@ -53,28 +53,33 @@ Once Triton server finishes starting up, it will display the status of all loade
 Use Morpheus to run the Anomalous Behavior Profiling Detection Pipeline with the pcap data. A pipeline has been configured in `run.py` with several command line options:
 
 ```bash
-python run.py --help
+$ python run.py --help
 Usage: run.py [OPTIONS]
 
 Options:
   --num_threads INTEGER RANGE     Number of internal pipeline threads to use
+                                  [x>=1]
   --pipeline_batch_size INTEGER RANGE
                                   Internal batch size for the pipeline. Can be
                                   much larger than the model batch size. Also
-                                  used for Kafka consumers
-
+                                  used for Kafka consumers  [x>=1]
   --model_max_batch_size INTEGER RANGE
-                                  Max batch size to use for the model
+                                  Max batch size to use for the model  [x>=1]
   --input_file PATH               Input filepath  [required]
   --output_file TEXT              The path to the file where the inference
                                   output will be saved.
-
   --model_fea_length INTEGER RANGE
-                                  Features length to use for the model
+                                  Features length to use for the model  [x>=1]
   --model_name TEXT               The name of the model that is deployed on
                                   Tritonserver
-
+  --iterative                     Iterative mode will emit dataframes one at a
+                                  time. Otherwise a list of dataframes is
+                                  emitted. Iterative mode is good for
+                                  interleaving source stages.
   --server_url TEXT               Tritonserver url  [required]
+  --file_type [auto|json|csv]     Indicates what type of file to read.
+                                  Specifying 'auto' will determine the file
+                                  type from the extension.
   --help                          Show this message and exit.
 ```
 
@@ -83,16 +88,10 @@ To launch the configured Morpheus pipeline with the sample data that is provided
 ```bash
 python run.py \
 	--input_file ../../data/abp_pcap_dump.jsonlines \
-	--output_file pcap_out.jsonlines \
+	--output_file ./pcap_out.jsonlines \
 	--model_name 'abp-pcap-xgb' \
 	--server_url localhost:8001
 ```
 Note: Both Morpheus and Trinton Inference Server containers must have access to the same GPUs in order for this example to work.
 
-The pipeline will process the input `pcap_dump.jsonlines` sample data and write it to `pcap_out.jsonlines`. Once complete, Morpheus will need to be manually stopped with Ctrl+C (Pipelines are meant to be continuously run).
-
-### Pipeline Visualization
-
-The script `run.py` will also generate a visualization of the pipeline at `<MORPHEUS_ROOT>/examples/abp_pcap_detection/pipeline.png`. You should see something similar to this:
-
-![ABP Detection Pipeline](img/abp_pcap_detection.png)
+The pipeline will process the input `pcap_dump.jsonlines` sample data and write it to `pcap_out.jsonlines`.

--- a/examples/abp_pcap_detection/run.py
+++ b/examples/abp_pcap_detection/run.py
@@ -16,19 +16,28 @@ import logging
 import os
 
 import click
-import psutil
 from abp_pcap_preprocessing import AbpPcapPreprocessingStage
 
+from morpheus.cli import FILE_TYPE_NAMES
+from morpheus.cli import str_to_file_type
 from morpheus.config import Config
 from morpheus.config import CppConfig
 from morpheus.config import PipelineModes
+from morpheus.pipeline.general_stages import AddClassificationsStage
+from morpheus.pipeline.general_stages import MonitorStage
+from morpheus.pipeline.inference.inference_triton import TritonInferenceStage
+from morpheus.pipeline.input.from_file import FileSourceStage
+from morpheus.pipeline.output.serialize import SerializeStage
+from morpheus.pipeline.output.to_file import WriteToFileStage
+from morpheus.pipeline.pipeline import LinearPipeline
+from morpheus.pipeline.preprocessing import DeserializeStage
 from morpheus.utils.logging import configure_logging
 
 
 @click.command()
 @click.option(
     "--num_threads",
-    default=psutil.cpu_count(),
+    default=os.cpu_count(),
     type=click.IntRange(min=1),
     help="Number of internal pipeline threads to use",
 )
@@ -54,7 +63,7 @@ from morpheus.utils.logging import configure_logging
 )
 @click.option(
     "--output_file",
-    default="pcap_out.jsonlines",
+    default="./pcap_out.jsonlines",
     help="The path to the file where the inference output will be saved.",
 )
 @click.option(
@@ -78,7 +87,7 @@ from morpheus.utils.logging import configure_logging
 @click.option("--server_url", required=True, help="Tritonserver url")
 @click.option(
     "--file_type",
-    type=click.Choice(["auto", "json", "csv"], case_sensitive=False),
+    type=click.Choice(FILE_TYPE_NAMES, case_sensitive=False),
     default="auto",
     help=("Indicates what type of file to read. "
           "Specifying 'auto' will determine the file type from the extension."),
@@ -114,19 +123,8 @@ def run_pipeline(
 
     kwargs = {}
 
-    from morpheus.pipeline.pipeline import LinearPipeline
-
     # Create a linear pipeline object
     pipeline = LinearPipeline(config)
-
-    from morpheus.pipeline.general_stages import AddClassificationsStage
-    from morpheus.pipeline.general_stages import MonitorStage
-    from morpheus.pipeline.inference.inference_triton import TritonInferenceStage
-    from morpheus.pipeline.input.from_file import FileSourceStage
-    from morpheus.pipeline.input.from_file import FileTypes
-    from morpheus.pipeline.output.serialize import SerializeStage
-    from morpheus.pipeline.output.to_file import WriteToFileStage
-    from morpheus.pipeline.preprocessing import DeserializeStage
 
     # Set source stage
     pipeline.set_source(
@@ -134,7 +132,7 @@ def run_pipeline(
             config,
             filename=input_file,
             iterative=iterative,
-            file_type=FileTypes(file_type),
+            file_type=str_to_file_type(file_type.lower()),
             filter_null=False,
         ))
 

--- a/examples/log_parsing/README.md
+++ b/examples/log_parsing/README.md
@@ -1,29 +1,17 @@
 <!--
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-#  * Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-#  * Neither the name of NVIDIA CORPORATION nor the names of its
-#    contributors may be used to endorse or promote products derived
-#    from this software without specific prior written permission.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
-# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 -->
 
 # Example cyBERT Morpheus Pipeline for Apache Log Parsing

--- a/morpheus/pipeline/output/to_file.py
+++ b/morpheus/pipeline/output/to_file.py
@@ -120,7 +120,7 @@ class WriteToFileStage(SinglePortStage):
             def node_fn(input: neo.Observable, output: neo.Subscriber):
 
                 # Ensure our directory exists
-                os.makedirs(os.path.dirname(self._output_file), exist_ok=True)
+                os.makedirs(os.path.realpath(os.path.dirname(self._output_file)), exist_ok=True)
 
                 # Open up the file handle
                 with open(self._output_file, "a") as out_file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,6 +167,16 @@ def reload_modules(request: pytest.FixtureRequest):
             importlib.reload(mod)
 
 
+@pytest.fixture(scope="function")
+def chdir_tmpdir(request: pytest.FixtureRequest, tmp_path):
+    """
+    Executes a test in the tmp_path directory
+    """
+    os.chdir(tmp_path)
+    yield
+    os.chdir(request.config.invocation_dir)
+
+
 def wait_for_camouflage(popen, root_dir, host="localhost", port=8000, timeout=5):
     ready = False
     elapsed_time = 0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,18 @@ def pytest_collection_modifyitems(items):
             item.add_marker(pytest.mark.use_cpp)
 
 
+def clear_handlers(logger):
+    handlers = logger.handlers.copy()
+    for h in handlers:
+        logger.removeHandler(h)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item, nextitem):
+    clear_handlers(logging.getLogger("morpheus"))
+    clear_handlers(logging.getLogger())
+
+
 @pytest.fixture(scope="function")
 def config_only_cpp():
     """

--- a/tests/test_file_in_out_stage_pipe.py
+++ b/tests/test_file_in_out_stage_pipe.py
@@ -52,3 +52,23 @@ def test_file_rw_pipe(tmp_path, config, output_type):
     # Somehow 0.7 ends up being 0.7000000000000001
     output_data = np.around(output_data, 2)
     assert output_data.tolist() == input_data.tolist()
+
+
+@pytest.mark.use_python
+@pytest.mark.usefixtures("chdir_tmpdir")
+def test_to_file_no_path(tmp_path, config):
+    """
+    Test to ensure issue #48 is fixed
+    """
+    input_file = os.path.join(TEST_DIRS.expeced_data_dir, "filter_probs.csv")
+    out_file = "test.csv"
+
+    assert os.path.realpath(os.curdir) == tmp_path.as_posix()
+
+    assert not os.path.exists(tmp_path / out_file)
+    pipe = LinearPipeline(config)
+    pipe.set_source(FileSourceStage(config, filename=input_file))
+    pipe.add_stage(WriteToFileStage(config, filename=out_file, overwrite=False))
+    pipe.run()
+
+    assert os.path.exists(tmp_path / out_file)


### PR DESCRIPTION
Fixes an issue where during the run of pytest `configure_logging` was being called multiple times resulting in several duplicate log handlers being added to the morpheus logger.

Fixes #63