### PR TITLE
Clear log handlers after each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,18 @@ def pytest_collection_modifyitems(items):
             item.add_marker(pytest.mark.use_cpp)
 
 
+def clear_handlers(logger):
+    handlers = logger.handlers.copy()
+    for h in handlers:
+        logger.removeHandler(h)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item, nextitem):
+    clear_handlers(logging.getLogger("morpheus"))
+    clear_handlers(logging.getLogger())
+
+
 @pytest.fixture(scope="function")
 def config_only_cpp():
     """


### PR DESCRIPTION
Fixes an issue where during the run of pytest `configure_logging` was being called multiple times resulting in several duplicate log handlers being added to the morpheus logger.

Fixes #63