### PR TITLE
Revert "Install new apt key"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,11 +42,8 @@ ARG TENSORRT_VERSION=8.2.1.3
 # Capture argument used for FROM
 ARG CUDA_VER
 
-
-
 # Install dependencies to build vcpkg dependencies
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub && \
-    apt-get update &&\
+RUN apt-get update &&\
     apt-get upgrade -y &&\
     curl -sL https://deb.nodesource.com/setup_12.x | bash - &&\
     apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Developers will need to execute 
```bash
docker pull docker.io/gpuci/miniforge-cuda:11.4-devel-ubuntu20.04
```
To ensure their base image is up to date.

This reverts commit f1de88fa3f65b1d179c3402496952b48edf7b4de.